### PR TITLE
Increase Worker replicas to reflect network

### DIFF
--- a/install-config.yaml
+++ b/install-config.yaml
@@ -6,7 +6,7 @@ metadata:
 compute:
 - hyperthreading: Enabled
   name: worker
-  replicas: 0
+  replicas: 2 
 
 controlPlane:
   hyperthreading: Enabled


### PR DESCRIPTION
Network has two compute (worker) nodes, which should be reflected in the
install.