### PR TITLE
Updated fake pullSecret

### DIFF
--- a/install-config.yaml
+++ b/install-config.yaml
@@ -26,5 +26,5 @@ platform:
 
 fips: false
 
-pullSecret: '{"auths":{"fake":{"auth": "bar"}}}' 
+pullSecret: '{"auths":{"fake":{"auth": "Zm9vOmJhcgo="}}}' 
 sshKey: 'ssh-ed25519 AAAA...'   


### PR DESCRIPTION
The later client is expecting the pullSecret auth format as base64 encoded.
The value supplied is "foo:bar" base64 encoded.